### PR TITLE
jest file watcher should ignore .git

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "jest": {
     "watchPathIgnorePatterns": [
-      "<rootDir>/node_modules/"
+      "<rootDir>/node_modules/",
+      "<rootDir>/.git/"
     ]
   }
 }


### PR DESCRIPTION
Added another pattern to jest's file watcher ignored paths in package.json, to exclude `.git` which has lots and lots of files we shouldn't be watching (a student ran into a system limit on watched files, he was running some Linux distro).  I can't see any reason why everyone shouldn't just ignore `.git` anyway though.