### PR TITLE
Lock `babel-loader` to 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@storybook/react": "^5.0.10",
     "@testing-library/jest-dom": "^4.0.0",
     "@testing-library/react": "^8.0.7",
-    "babel-loader": "^8.0.5",
+    "babel-loader": "8.1.0",
     "sass": "^1.53.0"
   },
   "jest": {


### PR DESCRIPTION
Storybook 5.0.10 depends on babel-loader 8.0.5 and react-scripts depends on 8.1.0. If we use ^8.0.5 then it will install 8.2.5 which isn't compatible.

I believe the upgrade to react-scripts 3.4.4 surfaced this.

Don't want to fix this one by one anymore.